### PR TITLE
Hide popup when opening tray menu

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,11 @@ function createTray() {
     tray.on("click", toggle);
 
     tray.on("right-click", () => {
+        // If the popup is already visible, hide it so the menu isn't obscured
+        if (win.isVisible()) {
+            hidePopup();
+        }
+
         const menuTemplate: Electron.MenuItemConstructorOptions[] = [
             {
                 label: "Show Clipboard", click: () => {


### PR DESCRIPTION
## Summary
- hide the popup before opening the tray context menu so the menu remains accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e405ffe5a08322b160257442e595c4