### PR TITLE
Adjust popup layout to avoid double scrollbars

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2,10 +2,17 @@
     color-scheme: light dark;
 }
 
+html,
 body {
-    margin: 12px;
+    height: 100%;
+}
+
+body {
+    margin: 0;
+    padding: 12px;
     font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
     background: transparent;
+    overflow: hidden;
 }
 
 .topbar {


### PR DESCRIPTION
## Summary
- prevent the popup body from scrolling independently by pinning it to the viewport height
- replace outer margin with padding and hide body overflow so only the list scrolls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e40dbc48cc83229dd5211aa5ef54ce